### PR TITLE
fix: actually set the max request size to 16 MiB

### DIFF
--- a/libs/joda/core/modules/network/CMakeLists.txt
+++ b/libs/joda/core/modules/network/CMakeLists.txt
@@ -67,4 +67,5 @@ target_link_libraries(joda-core-network-lib INTERFACE Boost::boost Boost::system
 # httplib
 #
 #########################################################
+target_compile_definitions(joda-core-network-lib INTERFACE CPPHTTPLIB_FORM_URL_ENCODED_PAYLOAD_MAX_LENGTH=16777216) # 16 MiB max request size
 target_link_libraries(joda-core-network-lib INTERFACE httplib)

--- a/libs/joda/core/modules/network/src/JodaServer.cpp
+++ b/libs/joda/core/modules/network/src/JodaServer.cpp
@@ -57,8 +57,6 @@ bool joda::network::JodaServer::start(const std::string& addr, int port) {
   apiv2::API::registerEndpoint(prefix, server);
   server.Get("/favicon.ico", favicon);
 
-  server.set_payload_max_length(1024 * 1024 * 16); // 16 MB max request size
-
   LOG(INFO) << "Starting server on " << addr << ":" << port;
   return server.listen(addr.c_str(), port);
 }


### PR DESCRIPTION
This is a workaround for httplib issue yhirose/cpp-httplib#1737

httplib has two parameters to control request size. `server.set_payload_max_length` can only restrict the size below `CPPHTTPLIB_FORM_URL_ENCODED_PAYLOAD_MAX_LENGTH`, but we actually want to increase it above its default of 8 KiB.